### PR TITLE
TGpoller: Prevent crash on bad curl exits

### DIFF
--- a/Telegram-API.tcl
+++ b/Telegram-API.tcl
@@ -258,7 +258,10 @@ proc tg2irc_pollTelegram {} {
 	global tg_bot_id tg_bot_token tg_update_id tg_poll_freq tg_channels utftable irc_botname
 	global MSG_TG_MSGSENT MSG_TG_AUDIOSENT MSG_TG_PHOTOSENT MSG_TG_DOCSENT MSG_TG_STICKERSENT MSG_TG_VIDEOSENT MSG_TG_VOICESENT MSG_TG_CONTACTSENT MSG_TG_LOCATIONSENT MSG_TC_VENUESENT MSG_TG_USERADD MSG_TG_USERLEFT MSG_TG_CHATTITLE MSG_TG_PICCHANGE MSG_TG_PICDELETE MSG_TG_UNIMPL
 
-	set result [exec curl --tlsv1.2 -s -X POST https://api.telegram.org/bot$tg_bot_id:$tg_bot_token/getUpdates?offset=$tg_update_id]
+	if { [catch { set result [exec curl --tlsv1.2 -s -X POST https://api.telegram.org/bot$tg_bot_id:$tg_bot_token/getUpdates?offset=$tg_update_id] } ] } {
+		putlog "Error while polling telegram. Result $result"
+		return 1
+	}
 
 	if {[jsonGetValue $result "" "ok"] eq "false"} {
 		putlog "Telegram-API: bad result from getUpdates method: [jsonGetValue $result "" "description"]"


### PR DESCRIPTION
 * If curl return a non 0 exit bot crash (but don't exit). It can
   happens when network is disconnected for example.
 * Sourround curl with catch fix this.